### PR TITLE
Hide mention of grades entirely if checkbox clicked.

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -267,9 +267,14 @@ function update_display() {
                 objects.push(assignment.commentCount + ' <i class="fa fa-comments" title="comments"></i>');
             }
 
-            li.innerHTML = '<div><strong>' + assignment.name + '</strong>, due ' + assignment.dueDate + '</div>' +
-                '<div>Grade: <strong>' + grade + '</strong>/' + assignment.maxGrade + '. ' +
+            li.innerHTML = '<div><strong>' + assignment.name + '</strong>, due ' + assignment.dueDate + '</div>';
+            if (gradeVisbility) {
+                li.innerHTML += '<div>Grade: <strong>' + grade + '</strong>/' + assignment.maxGrade + '. ' +
                 objects.join(', ') + '</div>';
+
+            } else {
+                li.innerHTML += '' + objects.join(', ') + '</div>';
+            }
 
             ul.appendChild(li);
         })


### PR DESCRIPTION
A slightly more visually appealing fix to #2.

![image](https://cloud.githubusercontent.com/assets/6826622/23911492/62891fb4-08b3-11e7-8c69-0a55adbe8b70.png)

I'm not entirely sure what the download icon is that normally appears next to the grade (none of my classes currently use LMOD to actually keep track of assignments so I don't really have a way to test this thoroughly myself.